### PR TITLE
SC#20 - Reports Dashboard Tile - Dynamically Show Desired Metrics

### DIFF
--- a/charts/report-statistics.js
+++ b/charts/report-statistics.js
@@ -34,6 +34,7 @@
     let html = '';
     let leading_section = [];
     let lagging_section = [];
+    let custom_section = [];
 
     function toFixedIfNecessary( value, dp = 2 ){
       return +parseFloat(value).toFixed( dp );
@@ -53,12 +54,21 @@
           `;
 
           // Place html within respective section.
-          if (stat['section']==='leading') {
-            leading_section.push(section_html);
-
-          } else {
-            lagging_section.push(section_html);
+          switch (stat['section']) {
+            case 'leading': {
+              leading_section.push(section_html);
+              break;
+            }
+            case 'lagging': {
+              lagging_section.push(section_html);
+              break;
+            }
+            case 'custom': {
+              custom_section.push(section_html);
+              break;
+            }
           }
+
         }
       });
     }
@@ -70,7 +80,7 @@
       jQuery.each(leading_section, function (idx, stat_html) {
         html += stat_html;
       });
-      html += `</div><br><br><br>`;
+      html += `</div><br><br>`;
     }
 
     // Display lagging section.
@@ -80,12 +90,22 @@
       jQuery.each(lagging_section, function (idx, stat_html) {
         html += stat_html;
       });
+      html += `</div><br><br>`;
+    }
+
+    // Display custom section.
+    if (custom_section.length > 0) {
+      html += `<h3><b>${window.wp_js_object.translations.sections.custom}</b></h3>`;
+      html += `<div style="display: flex; flex-flow: row wrap; justify-content: center; overflow: auto;">`;
+      jQuery.each(custom_section, function (idx, stat_html) {
+        html += stat_html;
+      });
       html += `</div>`;
     }
 
     // If available, create accountability chart div placeholder.
     if (stats['accountability']) {
-      html += `<br><br><br><h3><b>${window.lodash.escape(stats['accountability']['label'])}</b></h3>`;
+      html += `<br><br><h3><b>${window.lodash.escape(stats['accountability']['label'])}</b></h3>`;
       html += `<div id="accountability_chart_div" style="min-width: 75%; max-width: 75%; min-height: 500px; margin: auto;"></div>`;
     }
 

--- a/charts/report-statistics.php
+++ b/charts/report-statistics.php
@@ -64,6 +64,7 @@ class Disciple_Tools_Survey_Collection_Report_Statistics extends DT_Metrics_Char
                     'sections'  => [
                         'leading' => __( 'Leading Indicators', 'disciple-tools-survey-collection' ),
                         'lagging' => __( 'Lagging Indicators', 'disciple-tools-survey-collection' ),
+                        'custom' => __( 'Custom Indicators', 'disciple-tools-survey-collection' ),
                         'accountability' => [
                             'account' => __( 'Accounted', 'disciple-tools-survey-collection' ),
                             'not_account' => __( 'Not Accounted', 'disciple-tools-survey-collection' ),
@@ -154,6 +155,22 @@ class Disciple_Tools_Survey_Collection_Report_Statistics extends DT_Metrics_Char
                     ];
                 }
             }
+
+            // Package any identified custom fields.
+            if ( !empty( $raw_stats['stats_custom'] ) ){
+                $custom_field_settings = DT_Posts::get_post_field_settings( 'reports', false );
+                foreach ( $raw_stats['stats_custom'] as $field_key => $stat ){
+                    if ( isset( $custom_field_settings[$field_key], $custom_field_settings[$field_key]['name'] ) ){
+                        $packaged_stats[] = [
+                            'key' => $field_key,
+                            'label' => $custom_field_settings[$field_key]['name'],
+                            'section' => 'custom',
+                            'value' => $stat
+                        ];
+                    }
+                }
+            }
+
             $response['general'] = $packaged_stats;
 
             // Package any detected accountability stats.

--- a/post-type/module-base.php
+++ b/post-type/module-base.php
@@ -369,7 +369,7 @@ class Disciple_Tools_Survey_Collection_Base extends DT_Module_Base {
                 <?php
             }
             ?>
-            </div>
+            </div><br>
             <?php
         }
 

--- a/tile/custom-tile.php
+++ b/tile/custom-tile.php
@@ -115,6 +115,37 @@ class Disciple_Tools_Survey_Collection_Tile {
                 'all_time' => 'stats_invites_all_time'
             ]
         ];
+
+        // Capture additional custom fields which satisfy our requirements.
+        $supported_field_types = [ 'number' ];
+        $supported_field_tiles = [ 'tracking' ];
+        $ignored_fields = [
+            'status',
+            'assigned_to',
+            'submit_date',
+            'rpt_start_date',
+            'shares',
+            'prayers',
+            'invites',
+            'new_baptisms',
+            'new_groups',
+            'active_groups',
+            'participants',
+            'accountability'
+        ];
+        $custom_field_settings = DT_Posts::get_post_field_settings( 'reports', false );
+        foreach ( $custom_field_settings as $field_key => $setting ){
+            if ( isset( $setting['name'], $setting['type'], $setting['tile'] ) ){
+                if ( in_array( $setting['type'], $supported_field_types ) && in_array( $setting['tile'], $supported_field_tiles ) && !in_array( $field_key, $ignored_fields ) ){
+                    $stats_fields[] = [
+                        'label' => $setting['name'],
+                        'ytd' => 'stats_' . $field_key . '_ytd',
+                        'all_time' => 'stats_' . $field_key . '_all_time'
+                    ];
+                }
+            }
+        }
+
         if ( ( $post_type === 'reports' ) && $section === 'statistics' ) {
             $post = DT_Posts::get_post( $post_type, get_the_ID() );
             ?>

--- a/tile/dashboard-tile-template.php
+++ b/tile/dashboard-tile-template.php
@@ -3,8 +3,9 @@
     <div style="display: inline-block" class="stats-spinner loading-spinner"></div>
 </div>
 <div class="tile-subheader"><?php esc_html_e( 'All Time', 'disciple-tools-survey-collection' ) ?></div>
-<div class="tile-body tile-body--center">
+<div class="tile-body tile-body--center" style="overflow: auto;">
     <div>
+        <br><br>
         <p><?php esc_html_e( 'Reports with submission dates set in the future are not included within metric calculations.', 'disciple-tools-survey-collection' ) ?></p>
         <p style="text-align: center; display: none" id="empty_survey_collection_stats">
             <strong><?php esc_html_e( 'No data to show yet. You have no active reports', 'disciple-tools-survey-collection' ) ?></strong>
@@ -75,7 +76,8 @@
                     $key = 'stats_' . $field_key . '_all_time';
                     $stats[] = [
                         'key' => $key,
-                        'label' => sprintf( __( 'Total %s', 'disciple-tools-survey-collection' ), $field['name'] )
+                        'label' => sprintf( __( 'Total %s', 'disciple-tools-survey-collection' ), $field['name'] ),
+                        'section' => 'custom'
                     ];
                 }
             }
@@ -84,10 +86,25 @@
         // Package final stats shape and render html display.
         foreach ( $stats as $stat ) {
             if ( isset( $raw_stats[ $stat['key'] ] ) ) {
+
+                // Determine section.
+                switch ( $stat['section'] ) {
+                    case 'leading':
+                        $section = 'leading';
+                        break;
+                    case 'lagging':
+                        $section = 'lagging';
+                        break;
+                    default:
+                        $section = 'custom';
+                        break;
+                }
+
+                // Package final stats shape.
                 $packaged_stats[] = [
                     'key'   => $stat['key'],
                     'label' => $stat['label'],
-                    'section' => $stat['section'] ?? 'lagging',
+                    'section' => $section,
                     'value' => $raw_stats[ $stat['key'] ]
                 ];
             }
@@ -96,7 +113,7 @@
         do_action( 'survey_collection_metrics_dashboard_stats_html', $packaged_stats );
         ?>
 
-        <br><br>
+        <br>
         <a href="<?php echo esc_url( site_url() . '/metrics/disciple-tools-survey-collection-metrics/report_stats' ) ?>"
            class="button select-button"
            style="min-width: 100%;"><?php esc_html_e( 'See Global Dashboard', 'disciple-tools-survey-collection' ) ?></a>

--- a/tile/dashboard-tile-template.php
+++ b/tile/dashboard-tile-template.php
@@ -4,8 +4,7 @@
 </div>
 <div class="tile-subheader"><?php esc_html_e( 'All Time', 'disciple-tools-survey-collection' ) ?></div>
 <div class="tile-body tile-body--center" style="overflow: auto;">
-    <div>
-        <br><br>
+    <div style="margin-top: 150px;">
         <p><?php esc_html_e( 'Reports with submission dates set in the future are not included within metric calculations.', 'disciple-tools-survey-collection' ) ?></p>
         <p style="text-align: center; display: none" id="empty_survey_collection_stats">
             <strong><?php esc_html_e( 'No data to show yet. You have no active reports', 'disciple-tools-survey-collection' ) ?></strong>
@@ -52,6 +51,11 @@
                 'key' => 'stats_accountability_days_since',
                 'label' => __( 'Days Since Last Reported Accountability', 'disciple-tools-survey-collection' ),
                 'section' => 'lagging'
+            ],
+            [
+                'key' => 'stats_participants_all_time',
+                'label' => __( 'Total Participants', 'disciple-tools-survey-collection' ),
+                'section' => 'lagging'
             ]
         ];
 
@@ -66,7 +70,8 @@
             'invites',
             'new_baptisms',
             'new_groups',
-            'active_groups'
+            'active_groups',
+            'participants'
         ] );
 
         // Capture other metric fields within overall stats.


### PR DESCRIPTION
- fixes: #20 
---

- Custom fields are now dynamically detected and displayed within dashboard metrics and statistics record sections.
- Detected custom field metrics are placed under the `Custom Indicators` section.

![Screenshot 2023-07-18 at 12 41 20](https://github.com/DiscipleTools/disciple-tools-survey-collection/assets/19330800/e98dfb25-a588-4e38-818f-66fd6abcc763)

![Screenshot 2023-07-18 at 12 42 10](https://github.com/DiscipleTools/disciple-tools-survey-collection/assets/19330800/fc7b54ac-ae4c-44b6-b9ba-105142e370d9)

![Screenshot 2023-07-18 at 13 43 37](https://github.com/DiscipleTools/disciple-tools-survey-collection/assets/19330800/6380c413-4d8f-4b17-ae4f-959d2b6b289c)

![Screenshot 2023-07-18 at 13 46 25](https://github.com/DiscipleTools/disciple-tools-survey-collection/assets/19330800/b28d0c53-f7af-4e65-915f-0b35cdaea10d)
